### PR TITLE
build: add wolf android presets for x86 and x64 arch

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,11 +9,16 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: false
       matrix:
         config:
           - preset: android-arm64-debug
+          - preset: android-arm64-release
           - preset: android-arm-debug
+          - preset: android-arm-release
+          - preset: android-x86_64-debug
+          - preset: android-x86_64-release
+          - preset: android-x86-debug
+          - preset: android-x86-release
 
     runs-on: ubuntu-22.04
     env:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -77,9 +77,6 @@
                 "ANDROID": true,
                 "CMAKE_TOOLCHAIN_FILE": "$env{ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake",
                 "ANDROID_STL": "c++_shared",
-                "ANDROID_ABI": "arm64-v8a",
-                "CPU": "armv8",
-                "CMAKE_ANDROID_ARCH_ABI": "arm64-v8a",
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
                 "CMAKE_SYSTEM_NAME": "Android"
             }
@@ -145,6 +142,70 @@
             "displayName": "Android ARM eabi v7a Release",
             "description": "Sets android platform and release build type for armeabi-v7a arch",
             "inherits": "android-arm-debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            },
+            "environment": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "android-x86_64-debug",
+            "inherits": "base-android",
+            "displayName": "Android x86_64 Debug",
+            "description": "Sets android platform and debug build type for x86_64 arch",
+            "architecture": {
+                "value": "x86_64",
+                "strategy": "external"
+            },
+            "environment": {
+                "ANDROID_ABI": "x86_64",
+                "CMAKE_ANDROID_ARCH_ABI": "x86_64",
+                "CMAKE_BUILD_TYPE": "Debug"
+            },
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "ANDROID_ABI": "x86_64",
+                "CMAKE_ANDROID_ARCH_ABI": "x86_64"
+            }
+        },
+        {
+            "name": "android-x86_64-release",
+            "displayName": "Android x86_64 Release",
+            "description": "Sets android platform and release build type for x86_64 arch",
+            "inherits": "android-x86_64-debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            },
+            "environment": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "android-x86-debug",
+            "inherits": "base-android",
+            "displayName": "Android x86 Debug",
+            "description": "Sets android platform and debug build type for x86 arch",
+            "architecture": {
+                "value": "x86",
+                "strategy": "external"
+            },
+            "environment": {
+                "ANDROID_ABI": "x86",
+                "CMAKE_ANDROID_ARCH_ABI": "x86",
+                "CMAKE_BUILD_TYPE": "Debug"
+            },
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "ANDROID_ABI": "x86",
+                "CMAKE_ANDROID_ARCH_ABI": "x86"
+            }
+        },
+        {
+            "name": "android-x86-release",
+            "displayName": "Android x86 Release",
+            "description": "Sets android platform and release build type for x86 arch",
+            "inherits": "android-x86-debug",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
             },
@@ -221,6 +282,30 @@
             "displayName": "Android ARM eabi v7a Release",
             "description": "Build Android",
             "configurePreset": "android-arm-release"
+        },
+        {
+            "name": "android-x86_64-debug",
+            "displayName": "Android x86_64 Debug",
+            "description": "Build Android",
+            "configurePreset": "android-x86_64-debug"
+        },
+        {
+            "name": "android-x86_64-release",
+            "displayName": "Android x86_64 Release",
+            "description": "Build Android",
+            "configurePreset": "android-x86_64-release"
+        },
+        {
+            "name": "android-x86-debug",
+            "displayName": "Android x86 Debug",
+            "description": "Build Android",
+            "configurePreset": "android-x86-debug"
+        },
+        {
+            "name": "android-x86-release",
+            "displayName": "Android x86 Release",
+            "description": "Build Android",
+            "configurePreset": "android-x86-release"
         },
         {
             "name": "linux-x64-debug",


### PR DESCRIPTION
# Pull Request Checklist

Please check if your pull request fulfills the following requirements:

<!-- Please check the one that applies to this pull request using "x". -->
  * [x] The commit message follows our guidelines: <https://gitlab.playpod.ir/alpha/backend/server-services-next/-/blob/main/CONTRIBUTING.md#commit-message-format>
  * [ ] Tests for the changes have been added / updated (for feat / fix / refactor)
  * [ ] Docs for the changes have been added / updated (for feat / fix / refactor)

## Pull Request Type

What kind of change does this pull request introduce?

<!-- Please check the one that applies to this pull request using "x". -->
  * [x] Build: Changes that affect the build system or external dependencies
  * [ ] CD: Changes to our CD configuration files and scripts
  * [ ] CI: Changes to our CI configuration files and scripts
  * [ ] Docs: Documentation only changes
  * [ ] Feat: A new feature
  * [ ] Fix: A bug fix
  * [ ] Perf: A code change that improves performance
  * [ ] Refactor: A code change that neither fixes a bug nor adds a feature
  * [ ] Test: Adding missing tests or correcting existing tests

## What is the current behaviour?

<!-- Please describe the current behaviour that you are modifying or link to a relevant issue. -->
Issue #8 

## What is the new behaviour?

 There are 4 new cmake presets for android:
 - `android-x86_64-debug`
 - `android-x86_64-release`
 - `android-x86-debug`
 - `android-x86-release`

## Does this Pull Request introduce a breaking change?

<!-- Please check the one that applies to this pull request using "x". -->
  * [ ] Yes
  * [x] No

<!-- If this pull request contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Closes #8 