### PR TITLE
build: fix build on windows with all features disabled

### DIFF
--- a/wolf/CMakeLists.txt
+++ b/wolf/CMakeLists.txt
@@ -408,7 +408,7 @@ if (WOLF_TEST)
     # copy runtime dll files to the same directory as the executable.
     if(WIN32)
         add_custom_command(TARGET ${TEST_PROJECT_NAME} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:${TEST_PROJECT_NAME}> $<TARGET_FILE_DIR:${TEST_PROJECT_NAME}>
+            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${TEST_PROJECT_NAME}> $<TARGET_RUNTIME_DLLS:${TEST_PROJECT_NAME}> $<TARGET_FILE_DIR:${TEST_PROJECT_NAME}>
             COMMAND_EXPAND_LISTS
         )
     endif()


### PR DESCRIPTION
# Pull Request Checklist

Please check if your pull request fulfills the following requirements:

<!-- Please check the one that applies to this pull request using "x". -->
  * [x] The commit message follows our guidelines: <https://gitlab.playpod.ir/alpha/backend/server-services-next/-/blob/main/CONTRIBUTING.md#commit-message-format>
  * [ ] Tests for the changes have been added / updated (for feat / fix / refactor)
  * [ ] Docs for the changes have been added / updated (for feat / fix / refactor)

## Pull Request Type

What kind of change does this pull request introduce?

<!-- Please check the one that applies to this pull request using "x". -->
  * [x] Build: Changes that affect the build system or external dependencies
  * [ ] CD: Changes to our CD configuration files and scripts
  * [ ] CI: Changes to our CI configuration files and scripts
  * [ ] Docs: Documentation only changes
  * [ ] Feat: A new feature
  * [ ] Fix: A bug fix
  * [ ] Perf: A code change that improves performance
  * [ ] Refactor: A code change that neither fixes a bug nor adds a feature
  * [ ] Test: Adding missing tests or correcting existing tests

## What is the current behaviour?

<!-- Please describe the current behaviour that you are modifying or link to a relevant issue. -->
Issue #54

## What is the new behaviour?

invoking `cmake -S . --preset windows-x64-msvc-static && cmake --build --preset windows-x64-msvc-static` doesn't fail by build error related to `cmake -E` command.

## Does this Pull Request introduce a breaking change?

<!-- Please check the one that applies to this pull request using "x". -->
  * [ ] Yes
  * [x] No

<!-- If this pull request contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Closes #54 